### PR TITLE
Reference to the Accessibility Guidelines WG

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,10 +436,10 @@
                             </p>
                         </dd>
 
-						<dt><a href="http://www.w3.org/WAI/GL/">Web Content Accessibility Guidelines Working Group</a></dt>
+						<dt><a href="http://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a></dt>
 						<dd>
 							<p>
-								That Working Group is responsible for the development of WCAG; the Digital Publishing Working Group shold work together with that Working Group to ensure the inclusion of publication specific features.
+								That Working Group is responsible for the development of WCAG; the Digital Publishing Working Group should work together with that Working Group to ensure the inclusion of publication specific features.
 							</p>
 						</dd>
                     </dl>


### PR DESCRIPTION
Changed the name from “Web Content Accessibility Guidelines WG” to “Accessibility Guidelines WG”. Thanks @Ryladog.

Closes #13