### PR TITLE
Adding references to the ODRL documents as input.

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,10 @@
 
                             <li><a href="https://w3ctag.github.io/packaging-on-the-web/">Packaging on the Web</a>.
                             The definition of packaging for Packaged Web Publications should consider this format as (one of) its standard format(s).</li>
+
+                            <li><a href="https://www.w3.org/TR/odrl-model/">ODRL Information Model</a> and <a href="https://www.w3.org/TR/odrl-vocab/">ODRL Vocabulary &amp; Expression</a>.
+                            Publishers may need to attach their licenses to the assets within a publication.
+                            The ODRL vocabulary should be considered as a possible way of expressing those licenses.</li>
                         </ul>
 
                         <h5>Other Documents (Notes, Member Submissions, Working Drafts for Notes, etc.)</h5>


### PR DESCRIPTION
This in response to the comments of Thomson Reuters on the charter review.